### PR TITLE
Add support for smaller models

### DIFF
--- a/jacobian_saes/training/sparsity_metrics.py
+++ b/jacobian_saes/training/sparsity_metrics.py
@@ -2,9 +2,10 @@
 
 import torch
 from einops import rearrange
-from jaxtyping import Array, Float
+from jaxtyping import Float
+from torch import Tensor
 
-type Jacobian = Float[Array, "batch seq_pos k2 k1"]
+type Jacobian = Float[Tensor, "batch seq_pos k2 k1"]
 
 
 def l1(x: Jacobian):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "jacobian-saes"
+version = "0.1.0"
+readme = "README.md"
+dependencies = [
+    "transformer-lens==2.11.0",
+    "nnsight==0.3.7",
+    "orjson==3.10.13",
+    "transformers==4.46.1",
+]
+requires-python = ">= 3.12"
+
+[tool.setuptools]
+package-dir = {"" = "jacobian_saes"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-transformer-lens==2.11.0
-nnsight==0.3.7
-orjson==3.10.13
-git+https://github.com/EleutherAI/sae
-git+https://github.com/lucyfarnik/sae-auto-interp
-transformers==4.46.1
-kaleido=0.2.1

--- a/runners/traditional_sae_train.py
+++ b/runners/traditional_sae_train.py
@@ -28,7 +28,7 @@ parser.add_argument(
     type=str,
     default="70m",
     help="Pythia model size",
-    choices=["70m", "160m", "410m", "1b", "1.4b", "2.8b", "6.9b", "12b"],
+    choices=["14m", "31m", "70m", "160m", "410m", "1b", "1.4b", "2.8b", "6.9b", "12b"],
 )
 parser.add_argument("-p", "--precision", type=int, default=32, help="Floating point precision")
 parser.add_argument("--store-batch-size", type=int, default=16, help="Store batch size")
@@ -68,6 +68,8 @@ lr_warm_up_steps = total_training_steps // 100  # 1% of training
 lr_decay_steps = total_training_steps // 5  # 20% of training
 
 d_model_by_size = {
+    "14m": 128,
+    "31m": 256,
     "70m": 512,
     "160m": 768,
     "410m": 1024,
@@ -79,6 +81,8 @@ d_model_by_size = {
 }
 
 n_layers_by_size = {
+    "14m": 6,
+    "31m": 6,
     "70m": 6,
     "160m": 12,
     "410m": 24,

--- a/runners/train.py
+++ b/runners/train.py
@@ -12,6 +12,8 @@ from jacobian_saes import LanguageModelSAERunnerConfig, SAETrainingRunner
 from jacobian_saes.training.sparsity_metrics import sparsity_metrics
 
 d_model_by_size = {
+    "14m": 128,
+    "31m": 256,
     "70m": 512,
     "160m": 768,
     "gpt2-small": 768,
@@ -24,6 +26,8 @@ d_model_by_size = {
 }
 
 n_layers_by_size = {
+    "14m": 6,
+    "31m": 6,
     "70m": 6,
     "160m": 12,
     "gpt2-small": 12,
@@ -125,7 +129,17 @@ parser.add_argument(
     default="jacobian_saes_test",
     help="Wandb project name",
 )
+parser.add_argument(
+    "--model-deduped",
+    action=argparse.BooleanOptionalAction,
+    default=None,
+    help="Whether to use the deduped version of the model (default: True if a deduped version of this model is known to exist).",
+)
+
 args = parser.parse_args()
+
+if args.model_deduped is None:
+    args.model_deduped = args.model_size not in ["14m", "31m", "gpt2-small"]
 
 if torch.cuda.is_available():
     device = "cuda"
@@ -194,10 +208,11 @@ if args.model_preset is not None:
     else:
         raise ValueError(f"Model preset not yet supported: {args.model_preset}")
 
+model_name_suffix = "-deduped" if args.model_deduped else ""
 model_name = (
     "gpt2-small"
     if args.model_size == "gpt2-small"
-    else f"pythia-{args.model_size}-deduped"
+    else f"pythia-{args.model_size}{model_name_suffix}"
 )
 
 dataset_path = "apollo-research/monology-pile-uncopyrighted-tokenizer-" + (

--- a/runners/train.py
+++ b/runners/train.py
@@ -69,7 +69,7 @@ parser.add_argument(
     "--eval-n-batches", type=int, default=10, help="Number of eval batches"
 )
 parser.add_argument(
-    "--jacobian-coef", "-j", type=float, default=1, help="Jacobian coefficient"
+    "--jacobian-coef", "-j", type=float, default=None, help="Jacobian coefficient (default: 0.5*k^2/d_model)"
 )
 parser.add_argument("-k", type=int, default=32, help="TopK value")
 parser.add_argument("--layer", "-l", type=int, default=3, help="Layer to hook")
@@ -152,31 +152,23 @@ print("Using device:", device)
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 if args.model_preset is not None:
+    args.model_size = args.model_preset
+
     if args.model_preset == "410m":
-        args.model_size = "410m"
         if args.expansion_factor == 32:
             args.expansion_factor = 64
-        if args.jacobian_coef == 1:
-            # jac coeff should imo be 0.5 k^2 / d_model
-            args.jacobian_coef = 0.5
         if args.eval_batch_size == 8:
             args.eval_batch_size = 4
         if args.eval_n_batches == 10:
             args.eval_n_batches = 20
 
     elif args.model_preset == "1b":
-        args.model_size = "1b"
-        if args.jacobian_coef == 1:
-            args.jacobian_coef = 0.25
         if args.eval_batch_size == 8:
             args.eval_batch_size = 2
         if args.eval_n_batches == 10:
             args.eval_n_batches = 40
 
     elif args.model_preset == "2.8b":
-        args.model_size = "2.8b"
-        if args.jacobian_coef == 1:
-            args.jacobian_coef = 0.2
         if args.eval_batch_size == 8:
             args.eval_batch_size = 2
         if args.eval_n_batches == 10:
@@ -187,9 +179,6 @@ if args.model_preset is not None:
             args.store_batch_size = 8
 
     elif args.model_preset == "6.9b":
-        args.model_size = "6.9b"
-        if args.jacobian_coef == 1:
-            args.jacobian_coef = 0.125
         if args.buffer_size == 32:
             args.buffer_size = 2
         if args.store_batch_size == 16:
@@ -207,6 +196,13 @@ if args.model_preset is not None:
 
     else:
         raise ValueError(f"Model preset not yet supported: {args.model_preset}")
+
+
+d_model = d_model_by_size[args.model_size]
+
+if args.jacobian_coef is None:
+    args.jacobian_coef = 0.5 * (args.k ** 2) / d_model
+    print(f"Automatic jacobian_coef: {args.jacobian_coef:.6f}")
 
 model_name_suffix = "-deduped" if args.model_deduped else ""
 model_name = (
@@ -243,7 +239,7 @@ cfg = LanguageModelSAERunnerConfig(
     randomize_llm_weights=args.randomize_weights,
     hook_name=f"blocks.{args.layer}.ln2.hook_normalized",
     hook_layer=args.layer,
-    d_in=d_model_by_size[args.model_size],
+    d_in=d_model,
     activation_fn="topk",
     activation_fn_kwargs={"k": args.k},
     dataset_path=dataset_path,


### PR DESCRIPTION
This PR adds support for pythia 14m and 31m. It also ensure that the jacobian_coef is set to `0.5*k^2/d_model` by default without having to manually specify new presets.